### PR TITLE
Update deleteTask* methods to POSTs

### DIFF
--- a/src/main/java/mesosphere/dcos/client/DCOS.java
+++ b/src/main/java/mesosphere/dcos/client/DCOS.java
@@ -215,16 +215,16 @@ public interface DCOS extends Marathon {
     @Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
     GetTasksResponse getTasks(@Param("status") String status) throws DCOSException;
 
-    @RequestLine("DELETE /v2/tasks/delete?force={force}")
+    @RequestLine("POST /v2/tasks/delete?force={force}")
     @Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
     GetTasksResponse deleteTask(@Param("force") boolean force, DeleteTaskCriteria deleteTaskBody) throws DCOSException;
 
-    @RequestLine("DELETE /v2/tasks/delete?force={force}&scale=true")
+    @RequestLine("POST /v2/tasks/delete?force={force}&scale=true")
     @Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
     GetTasksResponse deleteTaskAndScale(@Param("force") boolean force, DeleteTaskCriteria deleteTaskBody)
             throws DCOSException;
 
-    @RequestLine("DELETE /v2/tasks/delete?force={force}&wipe=true")
+    @RequestLine("POST /v2/tasks/delete?force={force}&wipe=true")
     @Headers(HeaderUtils.MARATHON_API_SOURCE_HEADER)
     GetTasksResponse deleteTaskAndWipe(@Param("force") boolean force, DeleteTaskCriteria deleteTaskBody)
             throws DCOSException;


### PR DESCRIPTION
Destroying tasks is actually a POST to a delete endpoint - https://dcos.io/docs/1.9/deploying-services/marathon-api/#!/tasks/V2TasksDelete