### PR TITLE
Remove dependency on guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,6 @@
 			<version>${gson-version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava-version}</version>
-		</dependency>
-		<dependency>
 			<groupId>net.oauth.core</groupId>
 			<artifactId>oauth</artifactId>
 			<version>20100527</version>

--- a/src/main/java/mesosphere/client/common/HttpResponseException.java
+++ b/src/main/java/mesosphere/client/common/HttpResponseException.java
@@ -1,7 +1,5 @@
 package mesosphere.client.common;
 
-import com.google.common.base.MoreObjects;
-
 public abstract class HttpResponseException extends RuntimeException {
     private int status;
     private String message;
@@ -38,6 +36,14 @@ public abstract class HttpResponseException extends RuntimeException {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).omitNullValues().toString();
+        final StringBuilder string = new StringBuilder();
+        if (methodKey != null) {
+            string.append("Error calling ").append(methodKey).append(": ");
+        }
+        string.append(message).append(" (http status: ").append(status).append(")");
+        if (details != null) {
+            string.append("\n").append("Details: ").append(details);
+        }
+        return string.toString();
     }
 }

--- a/src/main/java/mesosphere/client/common/ssl/SSLUtils.java
+++ b/src/main/java/mesosphere/client/common/ssl/SSLUtils.java
@@ -15,20 +15,23 @@
  */
 package mesosphere.client.common.ssl;
 
-import com.google.common.base.Strings;
-import mesosphere.dcos.client.Config;
-import okio.ByteString;
-
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+
+import mesosphere.dcos.client.Config;
+import okio.ByteString;
 
 public final class SSLUtils {
 
@@ -57,7 +60,7 @@ public final class SSLUtils {
 						}
 					}
 			};
-		} else if (!Strings.isNullOrEmpty(certData) || !Strings.isNullOrEmpty(certFile)) {
+		} else if (!isNullOrEmpty(certData) || !isNullOrEmpty(certFile)) {
 			trustStore = createTrustStore(certData, certFile);
 		}
 		tmf.init(trustStore);
@@ -100,5 +103,9 @@ public final class SSLUtils {
 			trustStore.setCertificateEntry(alias, cert);
 		}
 		return trustStore;
+	}
+
+	private static boolean isNullOrEmpty(final String string) {
+		return string == null || string.isEmpty();
 	}
 }


### PR DESCRIPTION
We are consuming this project but have other dependencies which require a specific version of guava which is older than the version required here.  It looks like guava is only being used for a few utility methods so I am proposing removing this so that we can consume this without conflicts and avoid pulling in guava as a dependency for a few utility methods. 