### PR TITLE
Add parameters to docker images in metronome jobs

### DIFF
--- a/src/main/java/mesosphere/metronome/client/model/v1/Docker.java
+++ b/src/main/java/mesosphere/metronome/client/model/v1/Docker.java
@@ -2,8 +2,11 @@ package mesosphere.metronome.client.model.v1;
 
 import mesosphere.client.common.ModelUtils;
 
+import java.util.Collection;
+
 public class Docker {
     private String image;
+    private Collection<Parameter> parameters;
 
     public String getImage() {
         return image;
@@ -11,6 +14,14 @@ public class Docker {
 
     public void setImage(String image) {
         this.image = image;
+    }
+
+    public Collection<Parameter> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Collection<Parameter> parameters) {
+        this.parameters = parameters;
     }
 
     @Override

--- a/src/main/java/mesosphere/metronome/client/model/v1/Parameter.java
+++ b/src/main/java/mesosphere/metronome/client/model/v1/Parameter.java
@@ -1,0 +1,30 @@
+package mesosphere.metronome.client.model.v1;
+
+public class Parameter {
+    private String key;
+    private String value;
+
+    public Parameter() {
+    }
+
+    public Parameter(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
Currently parameters cannot be passed to metronome jobs, likely because that field is not mentioned in the [metronome API docs](https://dcos.github.io/metronome/docs/generated/api.html#v1_jobs_post). However, parameters [are included in the metronome JSON schema](https://github.com/dcos/metronome/blob/master/api/src/main/resources/public/api/v1/schema/jobspec.schema.json#L120-L153), and I've confirmed you can configure them in the DC/OS UI.

Parameters can configure things like the [docker init option](https://docs.docker.com/engine/reference/run/#specify-an-init-process) and [log drivers](https://docs.docker.com/engine/reference/run/#logging-drivers---log-driver).

I modeled the Parameters after the identical fields in the marathon API.